### PR TITLE
DD-1205: fixed enum of FileScheme in provenance-v2

### DIFF
--- a/lib/src/main/resources/bag/metadata/prov/v2/provenance.xsd
+++ b/lib/src/main/resources/bag/metadata/prov/v2/provenance.xsd
@@ -103,7 +103,7 @@
     <xs:element name="new" type="prov:ContentType"/>
     <xs:simpleType name="XmlFileScheme">
         <xs:restriction base="xs:anyURI">
-            <xs:enumeration value="http://easy.dans.knaw.nl/schemas/md/ddm/">
+            <xs:enumeration value="http://schemas.dans.knaw.nl/dataset/ddm-v2/">
                 <xs:annotation>
                     <xs:documentation>
                         The DANS Dataset Metadata scheme


### PR DESCRIPTION
Fixes DD-1205: fixed enum of FileScheme in provenance-v2

# Description of changes


# How to test


# Related PRs

* required by https://github.com/DANS-KNAW/easy-convert-bag-to-deposit/pull/109

# Notify
@DANS-KNAW/dataversedans
