### PR TITLE
DD-1627 Made valueURI and valueCode optional

### DIFF
--- a/lib/src/main/resources/md/ddm/v2/ddm.xsd
+++ b/lib/src/main/resources/md/ddm/v2/ddm.xsd
@@ -439,9 +439,14 @@
                         <xs:documentation>The URI of the scheme. For a SKOS scheme, the ConceptScheme in the 'skos:inScheme' value is expected</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="valueURI" use="required" type="xs:anyURI">
+                <xs:attribute name="valueURI" type="xs:anyURI">
                     <xs:annotation>
                         <xs:documentation>The URI of the value given in the text-node.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="valueCode" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>The code of the value given in the text-node.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
                 <xs:attribute name="subjectScheme" type="xs:string" fixed="ABR Rapporten" use="required">
@@ -551,7 +556,12 @@
                         <xs:documentation>The URI of the scheme. For a SKOS scheme, the ConceptScheme in the 'skos:inScheme' value is expected</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="valueURI" use="required" type="xs:anyURI">
+                <xs:attribute name="valueCode" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>The code of the value given in the text-node.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="valueURI" type="xs:anyURI">
                     <xs:annotation>
                         <xs:documentation>The URI of the value given in the text-node.</xs:documentation>
                     </xs:annotation>


### PR DESCRIPTION
Fixes DD-1627 

# Description of changes
Changed DDM v2 so that valueURI and valueCode are both optional. Exactly one of the two attributes must be used, but that is now checked in a separate rule. See DANS BagIt Profile rule 3.1.11

# Notify

@DANS-KNAW/core-systems
